### PR TITLE
feat: implement prestige calculator core module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "AdCapPlus",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "AdCapCore",
+            targets: ["AdCapCore"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "AdCapCore",
+            path: "Sources/AdCapCore"
+        ),
+        .testTarget(
+            name: "AdCapCoreTests",
+            dependencies: ["AdCapCore"],
+            path: "Tests/AdCapCoreTests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Ad_cap
+# AdCap+
+
+This repository contains lightweight Swift models that explore the prestige math
+behind the AdCap+ idle economy. The core of the project is a reusable
+`AngelInvestorCalculator` that turns lifetime earnings into prestige rewards and
+production multipliers, mirroring the systems documented in the design brief.
+
+## Packages
+
+The Swift package `AdCapPlus` exposes the `AdCapCore` library target.
+
+### AngelInvestorCalculator
+
+* Smoothly converts lifetime earnings into angel investors using configurable
+  parameters (threshold, scaling factor, and exponent).
+* Provides helper utilities to evaluate prestige resets, estimate production
+  multipliers with diminishing returns, and determine the earnings needed to hit
+  a target angel milestone.
+
+## Running Tests
+
+```bash
+swift test
+```

--- a/Sources/AdCapCore/Prestige/AngelInvestorCalculator.swift
+++ b/Sources/AdCapCore/Prestige/AngelInvestorCalculator.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// `AngelInvestorCalculator` encapsulates the prestige math used to determine
+/// how many angel investors a player earns from lifetime earnings and how those
+/// angels convert into production bonuses. The implementation favours smooth
+/// progression over dramatic spikes while still rewarding long-term play.
+public struct AngelInvestorCalculator: Sendable {
+    /// Tunable constants that describe how prestige should scale.
+    public struct Parameters: Equatable, Sendable {
+        /// Minimum lifetime earnings required before any angels are awarded.
+        public var activationEarnings: Decimal
+        /// Divides the post-threshold earnings to keep numbers approachable.
+        public var scalingFactor: Decimal
+        /// Exponent that controls how aggressively earnings are converted into angels.
+        public var growthExponent: Decimal
+        /// When `true`, the calculator rounds down to whole angels.
+        public var floorResults: Bool
+        /// Percentage boost applied per angel before diminishing returns.
+        public var linearAngelBonus: Decimal
+        /// Number of angels granted the full linear bonus before tapering.
+        public var diminishingReturnThreshold: Decimal
+        /// Factor that reduces the bonus per angel once past the threshold.
+        public var diminishingReturnFactor: Decimal
+
+        public init(
+            activationEarnings: Decimal = 100_000,
+            scalingFactor: Decimal = 5_200,
+            growthExponent: Decimal = 0.623,
+            floorResults: Bool = true,
+            linearAngelBonus: Decimal = 0.02,
+            diminishingReturnThreshold: Decimal = 500,
+            diminishingReturnFactor: Decimal = 0.0015
+        ) {
+            self.activationEarnings = activationEarnings
+            self.scalingFactor = scalingFactor
+            self.growthExponent = growthExponent
+            self.floorResults = floorResults
+            self.linearAngelBonus = linearAngelBonus
+            self.diminishingReturnThreshold = diminishingReturnThreshold
+            self.diminishingReturnFactor = diminishingReturnFactor
+        }
+    }
+
+    public var parameters: Parameters
+
+    public init(parameters: Parameters = Parameters()) {
+        self.parameters = parameters
+    }
+
+    /// Returns the total angels earned for the provided `lifetimeEarnings`.
+    ///
+    /// The formula normalises post-threshold earnings, applies a configurable
+    /// exponent, and optionally rounds down to the nearest whole angel.
+    public func angelsEarned(lifetimeEarnings: Decimal) -> Decimal {
+        guard lifetimeEarnings >= parameters.activationEarnings else {
+            return 0
+        }
+
+        let normalized = (lifetimeEarnings - parameters.activationEarnings) / parameters.scalingFactor + 1
+        let computed = powDecimal(normalized, parameters.growthExponent) - 1
+        let angels = max(computed, 0)
+        return parameters.floorResults ? floorDecimal(angels) : angels
+    }
+
+    /// Calculates the number of angels that would be received by resetting now
+    /// given the current angel total. The value is always non-negative.
+    public func angelsAvailableOnReset(lifetimeEarnings: Decimal, currentAngels: Decimal) -> Decimal {
+        let total = angelsEarned(lifetimeEarnings: lifetimeEarnings)
+        return max(total - currentAngels, 0)
+    }
+
+    /// Determines the production multiplier derived from a given number of angels.
+    ///
+    /// Up to `diminishingReturnThreshold` angels, each angel grants the full
+    /// `linearAngelBonus`. Beyond that point the marginal benefit gradually
+    /// decreases based on `diminishingReturnFactor` to keep late-game scaling in
+    /// check. The multiplier returned is expressed as a factor (e.g. `1.20` for
+    /// a 20% boost).
+    public func productionMultiplier(forAngels angels: Decimal) -> Decimal {
+        guard angels > 0 else { return 1 }
+
+        let threshold = parameters.diminishingReturnThreshold
+        let perAngel = parameters.linearAngelBonus
+
+        if angels <= threshold {
+            return 1 + angels * perAngel
+        }
+
+        let guaranteedBonus = threshold * perAngel
+        let surplus = angels - threshold
+        let diminishingBonus = diminishingBonus(forSurplus: surplus, baseBonus: perAngel)
+        return 1 + guaranteedBonus + diminishingBonus
+    }
+
+    /// Computes the lifetime earnings required to reach a desired amount of
+    /// angels. The method never returns a value below `activationEarnings` and
+    /// gracefully handles requests lower than the current total angels.
+    public func earningsRequired(forTargetAngels targetAngels: Decimal) -> Decimal {
+        let clampedTarget = max(targetAngels, 0)
+        guard clampedTarget > 0 else { return parameters.activationEarnings }
+
+        let exponent = Decimal(1) / parameters.growthExponent
+        let growth = powDecimal(clampedTarget + 1, exponent)
+        let epsilon = Decimal(0.000_001)
+        let earnings = (growth - 1 + epsilon) * parameters.scalingFactor + parameters.activationEarnings
+        return max(earnings, parameters.activationEarnings)
+    }
+
+    // MARK: - Private helpers
+
+    private func diminishingBonus(forSurplus surplus: Decimal, baseBonus: Decimal) -> Decimal {
+        guard surplus > 0 else { return 0 }
+
+        let factor = parameters.diminishingReturnFactor
+        let numerator = logDecimal(1 + surplus * factor)
+        return baseBonus * numerator / factor
+    }
+
+    private func powDecimal(_ value: Decimal, _ exponent: Decimal) -> Decimal {
+        let base = NSDecimalNumber(decimal: value).doubleValue
+        let exp = NSDecimalNumber(decimal: exponent).doubleValue
+        return Decimal(pow(base, exp))
+    }
+
+    private func logDecimal(_ value: Decimal) -> Decimal {
+        let base = NSDecimalNumber(decimal: value).doubleValue
+        return Decimal(log(base))
+    }
+
+    private func floorDecimal(_ value: Decimal) -> Decimal {
+        var mutable = value
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &mutable, 0, .down)
+        return rounded
+    }
+}

--- a/Tests/AdCapCoreTests/AngelInvestorCalculatorTests.swift
+++ b/Tests/AdCapCoreTests/AngelInvestorCalculatorTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import AdCapCore
+
+final class AngelInvestorCalculatorTests: XCTestCase {
+    private let calculator = AngelInvestorCalculator()
+
+    func testNoAngelsBelowActivationThreshold() {
+        XCTAssertEqual(calculator.angelsEarned(lifetimeEarnings: 50_000), 0)
+    }
+
+    func testAngelsIncreaseSmoothly() {
+        let first = calculator.angelsEarned(lifetimeEarnings: 250_000)
+        let second = calculator.angelsEarned(lifetimeEarnings: 1_250_000)
+        let third = calculator.angelsEarned(lifetimeEarnings: 6_000_000)
+
+        XCTAssertLessThan(first, second)
+        XCTAssertLessThan(second, third)
+        XCTAssertEqual(first, 7)
+        XCTAssertEqual(second, 27)
+        XCTAssertEqual(third, 79)
+    }
+
+    func testResetCalculationNeverNegative() {
+        let angels = calculator.angelsAvailableOnReset(lifetimeEarnings: 2_000_000, currentAngels: 5_000)
+        XCTAssertEqual(angels, 0)
+    }
+
+    func testResetCalculationMatchesDifference() {
+        let total = calculator.angelsEarned(lifetimeEarnings: 5_500_000)
+        let current: Decimal = 20
+        let available = calculator.angelsAvailableOnReset(lifetimeEarnings: 5_500_000, currentAngels: current)
+        XCTAssertEqual(available, max(total - current, 0))
+    }
+
+    func testProductionMultiplierWithDiminishingReturns() {
+        let modest = calculator.productionMultiplier(forAngels: 100)
+        let large = calculator.productionMultiplier(forAngels: 2_000)
+
+        XCTAssertGreaterThan(modest, 1)
+        XCTAssertGreaterThan(large, modest)
+
+        let incrementalEarly = calculator.productionMultiplier(forAngels: 110) - calculator.productionMultiplier(forAngels: 100)
+        let incrementalLate = calculator.productionMultiplier(forAngels: 2_010) - calculator.productionMultiplier(forAngels: 2_000)
+        XCTAssertGreaterThan(incrementalEarly, incrementalLate)
+    }
+
+    func testEarningsRequiredIsInverseOfAngelsEarned() {
+        let targetAngels: Decimal = 120
+        let required = calculator.earningsRequired(forTargetAngels: targetAngels)
+        let earned = calculator.angelsEarned(lifetimeEarnings: required)
+        XCTAssertGreaterThanOrEqual(earned, targetAngels)
+    }
+}


### PR DESCRIPTION
## Summary
- add a Swift package manifest for the AdCapCore library
- implement a configurable AngelInvestorCalculator that models prestige math and production bonuses
- cover the prestige calculations with unit tests and update the README for local usage

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e361ef6d9c8332a35f6e9d68b0139f