### PR TITLE
feat: expose progress towards next angel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The Swift package `AdCapPlus` exposes the `AdCapCore` library target.
 * Provides helper utilities to evaluate prestige resets, estimate production
   multipliers with diminishing returns, and determine the earnings needed to hit
   a target angel milestone.
+* Exposes progress tracking to show how close the player is to their next
+  angel, making it easy to drive UI meters or reset prompts.
 
 ## Running Tests
 

--- a/Tests/AdCapCoreTests/AngelInvestorCalculatorTests.swift
+++ b/Tests/AdCapCoreTests/AngelInvestorCalculatorTests.swift
@@ -50,4 +50,15 @@ final class AngelInvestorCalculatorTests: XCTestCase {
         let earned = calculator.angelsEarned(lifetimeEarnings: required)
         XCTAssertGreaterThanOrEqual(earned, targetAngels)
     }
+
+    func testProgressTowardsNextAngelMonotonicallyIncreases() {
+        XCTAssertEqual(calculator.progressTowardsNextAngel(lifetimeEarnings: 50_000), 0)
+
+        let mid = calculator.progressTowardsNextAngel(lifetimeEarnings: 250_000)
+        let higher = calculator.progressTowardsNextAngel(lifetimeEarnings: 260_000)
+
+        XCTAssertGreaterThan(mid, 0)
+        XCTAssertLessThan(mid, 1)
+        XCTAssertGreaterThan(higher, mid)
+    }
 }


### PR DESCRIPTION
## Summary
- add a progress helper to `AngelInvestorCalculator` so prestige UIs can show fractional advancement
- share the raw angel computation and clamp negative values before rounding
- document the new capability and cover it with unit tests

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e36592a59c833292668bebe60b0bf9